### PR TITLE
interactionCreateハンドラを handlers/interactionCreate 配下へ移設

### DIFF
--- a/handlers/interactionCreate.mjs
+++ b/handlers/interactionCreate.mjs
@@ -1,7 +1,7 @@
 // handlers/interactionCreate.mjs
 import { EmbedBuilder } from "discord.js";
-import handleButtonInteraction from "../interactions/buttonHandlers.mjs";
-import handleModalInteraction from "../interactions/modalHandlers.mjs";
+import handleButtonInteraction from "./interactionCreate/buttonHandlers.mjs";
+import handleModalInteraction from "./interactionCreate/modalHandlers.mjs";
 import config from "../config.mjs";
 
 export default async (interaction) => {

--- a/handlers/interactionCreate/buttonHandlers.mjs
+++ b/handlers/interactionCreate/buttonHandlers.mjs
@@ -3,7 +3,7 @@ import {
   deleteconfirm,
   createRpDeleteConfirmButtons,
   createLoginResultButtons,
-} from "../components/buttons.mjs";
+} from "../../components/buttons.mjs";
 import {
   ModalBuilder,
   TextInputBuilder,
@@ -13,21 +13,21 @@ import {
 import {
   timeout_confirm,
   timeout_cancel,
-} from "../commands/slashs/suyasuya.mjs";
-import { Point, IdleGame } from "../models/database.mjs";
+} from "../../commands/slashs/suyasuya.mjs";
+import { Point, IdleGame } from "../../models/database.mjs";
 // 放置ゲームの人口を更新する関数をインポート
 import {
   getSingleUserUIData,
   formatNumberJapanese_Decimal,
   formatNumberDynamic,
-} from "../idle-game/idle-game-calculator.mjs";
+} from "../../idle-game/idle-game-calculator.mjs";
 import Decimal from "break_infinity.js";
-import { safeDelete } from "../utils/messageutil.mjs";
+import { safeDelete } from "../../utils/messageutil.mjs";
 import {
   checkLoginBonusEligibility,
   executeLoginBonus,
-} from "../utils/loginBonusSystem.mjs";
-import config from "../config.mjs";
+} from "../../utils/loginBonusSystem.mjs";
+import config from "../../config.mjs";
 
 export default async function handleButtonInteraction(interaction) {
   //以下変数定義

--- a/handlers/interactionCreate/modalHandlers.mjs
+++ b/handlers/interactionCreate/modalHandlers.mjs
@@ -5,17 +5,17 @@ import {
   ButtonBuilder,
   ButtonStyle,
 } from "discord.js";
-import config from "../config.mjs";
+import config from "../../config.mjs";
 import {
   replytoDM,
   replyfromDM,
   createRpDeleteRequestButton,
-} from "../components/buttons.mjs";
+} from "../../components/buttons.mjs";
 //RP機能周りimport
-import { sendWebhookAsCharacter } from "../utils/webhook.mjs";
-import { Character, Icon, Point, sequelize } from "../models/database.mjs";
-import { updatePoints } from "../commands/slashs/roleplay.mjs"; // updatePointsをインポート
-import { uploadFile, deleteFile } from "../utils/localStorage.mjs";
+import { sendWebhookAsCharacter } from "../../utils/webhook.mjs";
+import { Character, Icon, Point, sequelize } from "../../models/database.mjs";
+import { updatePoints } from "../../commands/slashs/roleplay.mjs"; // updatePointsをインポート
+import { uploadFile, deleteFile } from "../../utils/localStorage.mjs";
 //RP周りここまで
 
 export default async function handleModalInteraction(interaction) {


### PR DESCRIPTION
### Motivation
- `interaction` 系の処理配置を `messageCreate` と近い構成に揃えてプロジェクト構成を分かりやすくするため。 
- 大きな仕様変更は避け、まずはファイル移動と参照修正を優先する目的で実施しました。

### Description
- `interactions/buttonHandlers.mjs` を `handlers/interactionCreate/buttonHandlers.mjs` へ移動し、相対 import を移動先に合わせて更新しました。 
- `interactions/modalHandlers.mjs` を `handlers/interactionCreate/modalHandlers.mjs` へ移動し、相対 import を移動先に合わせて更新しました。 
- `handlers/interactionCreate.mjs` はイベント入口として残し、内部の `import` を `./interactionCreate/...` へ更新しました。 
- ロジックの変更は行っておらず、挙動は従来通りになるよう参照パスのみ調整しています。 

### Testing
- `npx prettier --check handlers/interactionCreate.mjs handlers/interactionCreate/buttonHandlers.mjs handlers/interactionCreate/modalHandlers.mjs` を実行し、フォーマットチェックは成功しました。 
- `node -e "import('./handlers/interactionCreate.mjs').then(()=>console.log('ok'))"` を試行したところ、環境変数（DB接続設定）未設定に起因する `sequelize` 初期化エラーで停止しましたが、このエラーは今回の移設作業とは無関係であることを確認しています。 
- ファイル移動後にプロジェクトのハンドラ参照 (`main.mjs` のローダー) に変更は加えておらず、動作に影響を与えないことを意図しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c394a8ece883298bed3c2d76710a1f)