### PR TITLE
Add character-notation help button and 'Next/Ascension' info display for Rev2 characters

### DIFF
--- a/components/buttons.mjs
+++ b/components/buttons.mjs
@@ -154,6 +154,20 @@ export function createLoginResultButtons() {
   );
 }
 
+/**
+ * ロスアカのステシ呼び出し記法チュートリアル表示ボタン
+ * @returns {import('discord.js').ActionRowBuilder}
+ */
+export function createCharacterNotationHelpButton() {
+  const notationHelpButton = new ButtonBuilder()
+    .setCustomId("show_character_notation_help")
+    .setLabel("ロスアカ記法ヘルプ")
+    .setStyle(ButtonStyle.Secondary)
+    .setEmoji("📘");
+
+  return new ActionRowBuilder().addComponents(notationHelpButton);
+}
+
 export const toggleLogiboNotificationButton = new ButtonBuilder()
   .setCustomId("toggle_logibo_notification")
   .setLabel("通知設定を切り替える")

--- a/handlers/interactionCreate/buttonHandlers.mjs
+++ b/handlers/interactionCreate/buttonHandlers.mjs
@@ -3,6 +3,7 @@ import {
   deleteconfirm,
   createRpDeleteConfirmButtons,
   createLoginResultButtons,
+  createCharacterNotationHelpButton,
 } from "../../components/buttons.mjs";
 import {
   ModalBuilder,
@@ -342,6 +343,35 @@ export default async function handleButtonInteraction(interaction) {
       content: helpText,
       ephemeral: true,
     });
+  } else if (interaction.customId === "show_character_notation_help") {
+    const helpText = `### ロスアカ ステシ呼び出し記法（閲覧チュートリアル）
+以下の記法は、基本的に \`r2p000001\` のようなID部分を対象キャラクターIDに置き換えて使います。
+
+- \`r2p000001\` : ステータスシートURL付き基本表示
+- \`r2p000001!\` : ステータス・スキル表示（ゲージあり）
+- \`r2p000001?\` : ステータスcompact・スキル表示
+- \`r2p000001??\` : ステータスcompact・スキル表示＋装備
+- \`r2p000001$\` : 育成予算目安一覧
+- \`r2p000001n\` : ネクスト・アセンション表示
+
+---
+### 目標Lv指定（将来値シミュレート）
+\`r2p000001\`（生の基本表示）以外は、末尾に目標Lvを続けるとそのLv時点の目安で表示できます。
+
+- \`r2p000001!30\` : ゲージあり表示を目標Lv30で確認
+- \`r2p000001?45\` : compact表示を目標Lv45で確認
+- \`r2p000001??60\` : compact＋装備を目標Lv60で確認
+- \`r2p000001$50\` : 目標Lv50までの育成予算目安
+- \`r2p000001n\` : ネクスト・アセンション表示（現在値）
+- \`r2p000001n30\` : ネクスト・アセンション表示（目標Lv30の必要経験値表示）
+
+-# この案内はあなたにだけ表示されています。`;
+    await interaction.reply({
+      content: helpText,
+      ephemeral: true,
+      components: [createCharacterNotationHelpButton()],
+    });
+    return;
     // --- ここまでが、あまやどんぐりのログインボーナス処理 ---
     //ログボのDM通知変更
   } else if (interaction.customId === "toggle_logibo_notification") {

--- a/handlers/messageCreate/reactionAndShortcutBlock.mjs
+++ b/handlers/messageCreate/reactionAndShortcutBlock.mjs
@@ -6,9 +6,11 @@ import {
   getCharacterSummaryCompact,
   getCharacterBasicInfo,
   getCharacterBudgetInfo,
+  getCharacterNextInfo,
 } from "../../utils/characterApi.mjs";
 import { unlockHiddenAchievements } from "../../utils/achievements.mjs";
 import config from "../../config.mjs";
+import { createCharacterNotationHelpButton } from "../../components/buttons.mjs";
 
 // ロスアカ短縮形
 const rev2urlPatterns = {
@@ -36,6 +38,7 @@ const rev2detailCompactWithEquipmentMatch = message.content.match(
 const rev2detailCompactMatch = message.content.match(
   /^(r2[pn][0-9]{6})\?(\d+)?$/
 );
+const rev2nextInfoMatch = message.content.match(/^(r2[pn][0-9]{6})n(\d+)?$/);
 const rev2urlmatch = message.content.match(
   /^(ils|snd|sce|nvl|not|com)(\d{8})$/
 );
@@ -233,6 +236,21 @@ else if (message.content.match(/^r2[pn][0-9]{6}(?:\$|予算)(\d+)?$/)) {
     content: replyMessage,
   });
 }
+// ネクスト・アセンション表示
+else if (rev2nextInfoMatch) {
+  const characterId = rev2nextInfoMatch[1];
+  const targetLevel = rev2nextInfoMatch[2]
+    ? parseInt(rev2nextInfoMatch[2], 10)
+    : null;
+
+  await message.channel.sendTyping();
+  const replyMessage = await getCharacterNextInfo(characterId, targetLevel);
+
+  await message.reply({
+    content: replyMessage,
+    allowedMentions: { repliedUser: false },
+  });
+}
 //ロスアカ (URL + 簡易情報)
 else if (message.content.match(/^r2[pn][0-9]{6}$/)) {
   const characterId = message.content;
@@ -246,6 +264,7 @@ else if (message.content.match(/^r2[pn][0-9]{6}$/)) {
   await message.reply({
     flags: [4096], //@silent
     content: replyMessage,
+    components: [createCharacterNotationHelpButton()],
   });
 }
 //PPP

--- a/utils/characterApi.mjs
+++ b/utils/characterApi.mjs
@@ -421,6 +421,93 @@ export async function getCharacterBasicInfo(characterId) {
   }
 }
 
+function createNextAbilitySection(character) {
+  if (!Array.isArray(character?.nexts) || character.nexts.length === 0) {
+    return "";
+  }
+
+  const typePriority = new Map([
+    ["ネクスト", 0],
+    ["アセンション", 1],
+  ]);
+
+  const visibleNexts = character.nexts
+    .filter((next) => next?.is_visible && next?.accepted)
+    .sort((a, b) => {
+      const pa = typePriority.has(a.type) ? typePriority.get(a.type) : 99;
+      const pb = typePriority.has(b.type) ? typePriority.get(b.type) : 99;
+      return pa - pb;
+    });
+
+  if (visibleNexts.length === 0) {
+    return "";
+  }
+
+  return visibleNexts
+    .map((next) => {
+      const rubyText = next.ruby ? `（${next.ruby}）` : "";
+      const rankText = next.rank ? `ランク${next.rank}` : "ランク-";
+      const descriptionText = (next.description || "説明なし").replace(/\r\n/g, "\n");
+      const annotationText = next.annotation
+        ? `\n（${next.annotation.replace(/\r\n/g, "\n")}）`
+        : "";
+
+      return `${next.type}：${next.name}${rubyText}　${rankText}\n${descriptionText}${annotationText}`;
+    })
+    .join("\n\n");
+}
+
+/**
+ * ネクスト・アセンション情報付き表示を生成する関数
+ * @param {string} characterId
+ * @param {number|null} [targetLevel=null] - 目標レベル（PC時のみ表示に反映）
+ * @returns {Promise<string>}
+ */
+export async function getCharacterNextInfo(characterId, targetLevel = null) {
+  try {
+    const apiData = await getCharacterDetail(characterId);
+
+    if (!apiData || !apiData.character) {
+      return `キャラクター「${characterId}」の情報取得に失敗しました。IDが正しいか確認してください。`;
+    }
+
+    const { character } = apiData;
+    const statePrefix = getStatePrefix(character);
+    const rootsDisplay = getRootsDisplay(character.roots);
+
+    let reply = "";
+    if (isNpcCharacter(character) || character.owner) {
+      reply = createNonPcSummaryHeader(character, statePrefix);
+    } else {
+      const licenseDisplay = formatLicenseDisplay(character.licenses);
+      const gameParams = await getGameParameters();
+      const levelplus = createLevelInfoString(character, gameParams, targetLevel);
+      const testa =
+        character.testament < 50 || character.testament >= 100
+          ? `${character.testament}`
+          : character.testament < 80
+            ? `⚠️${character.testament}`
+            : `⚠️${character.testament}⚠️`;
+
+      reply = `${statePrefix}「${character.name}」${rootsDisplay}×${character.generation.name}${licenseDisplay}\n`;
+      reply += `Lv.${character.level} Exp.${character.exp}/${character.exp_to_next}${levelplus} Testament.${testa}`;
+    }
+
+    const nextSection = createNextAbilitySection(character);
+    if (!nextSection) {
+      return `${reply}\nネクスト・アセンションがありません。`;
+    }
+
+    return `${reply}\n\`\`\`\n${nextSection}\n\`\`\``;
+  } catch (error) {
+    console.error(
+      `[エラー] ${characterId} のネクスト情報作成処理でエラーが発生しました:`,
+      error
+    );
+    return `情報取得中にエラーが発生しました。しばらくしてからもう一度お試しください。`;
+  }
+}
+
 /**
  * 【高レベル関数】（PC/EXPC判別ロジックを追加）
  * キャラクター情報を取得し、PCかEXPCかによって整形されたサマリ文字列を返します。


### PR DESCRIPTION
### Motivation
- Provide users quick access to a short tutorial for Rev2 character notation and a way to view "ネクスト／アセンション" details from chat shortcuts. 
- Surface the notation help as a UI element when showing basic character info to improve discoverability.

### Description
- Added `createCharacterNotationHelpButton` to `components/buttons.mjs` to create a dedicated secondary button with emoji for the notation help. 
- Implemented a new handler branch in `handlers/interactionCreate/buttonHandlers.mjs` for `show_character_notation_help` that replies with a compact tutorial and returns an ephemeral response. 
- Added `getCharacterNextInfo` and helper `createNextAbilitySection` to `utils/characterApi.mjs` to fetch and format ネクスト／アセンション information with optional target level support. 
- Wired message shortcut detection for `r2...n` patterns in `handlers/messageCreate/reactionAndShortcutBlock.mjs` to call `getCharacterNextInfo` and reply; also included the notation help button on basic character info replies. 
- Minor whitespace/newline cleanup for `toggleLogiboNotificationButton`.

### Testing
- Ran the project's automated test suite with `npm test` and static checks with `npm run lint`, and they completed without failures. 
- No new automated tests were added for the new formatting/handler logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9a3baf708329afd20b128bd2bb41)